### PR TITLE
Fix for -X<Method> parsing

### DIFF
--- a/assets/supportedOptions.js
+++ b/assets/supportedOptions.js
@@ -1,31 +1,101 @@
-// list of all supported options that are supported by this module
-
+// list of all options that are supported by this module
+/* eslint-disable max-len */
 let supportedOptions = [
-  '-V',
-  '--version',
-  '-A',
-  '--user-agent',
-  '-d',
-  '--data',
-  '--data-raw',
-  '--data-ascii',
-  '--data-urlencode',
-  '--data-binary',
-  '-F',
-  '--form',
-  '-G',
-  '--get',
-  '-H',
-  '--header',
-  '-X',
-  '--request',
-  '-I',
-  '--head',
-  '-T',
-  '--upload-file',
-  '--url',
-  '--basic',
-  '-u',
-  '--user'];
-
+  {
+    short: '-A',
+    long: '--user-agent',
+    description: 'An optional user-agent string',
+    format: '<string>',
+    collectValues: false
+  },
+  {
+    short: '-d',
+    long: '--data',
+    description: 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    long: '--data-raw',
+    description: 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    long: '--data-ascii',
+    description: 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    long: '--data-urlencode',
+    description: 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    long: '--data-binary',
+    description: 'Data sent as-is',
+    format: '[string]',
+    collectValues: false
+  },
+  {
+    short: '-F',
+    long: '--form',
+    description: 'A single form-data field',
+    format: '<name=content>',
+    collectValues: true
+  },
+  {
+    short: '-G',
+    long: '--get',
+    description: 'Forces the request to be sent as GET, with the --data parameters appended to the query string',
+    collectValues: false
+  },
+  {
+    short: '-H',
+    long: '--header',
+    description: 'Add a header (can be used multiple times)',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    short: '-X',
+    long: '--request',
+    description: 'Specify a custom request method to be used',
+    format: '[string]',
+    collectValues: false
+  },
+  {
+    short: '-I',
+    long: '--head',
+    description: 'Forces the request to be sent as HEAD, with the --data parameters appended to the query string',
+    collectValues: false
+  },
+  {
+    short: '-T',
+    long: '--upload-file',
+    description: 'Forces the request to be sent as PUT with the specified local file to the server',
+    format: '[string]',
+    collectValues: true
+  },
+  {
+    long: '--url',
+    description: 'An alternate way to specify the URL',
+    format: '[string]',
+    collectValues: false
+  },
+  {
+    long: '--basic',
+    description: 'Overrides previous auth settings',
+    collectValues: false
+  },
+  {
+    short: '-u',
+    long: '--user',
+    description: 'Basic auth ( -u <username:password>)',
+    format: '[string]',
+    collectValues: false
+  }
+];
 module.exports = supportedOptions;

--- a/assets/supportedOptions.js
+++ b/assets/supportedOptions.js
@@ -1,0 +1,31 @@
+// list of all supported options that are supported by this module
+
+let supportedOptions = [
+  '-V',
+  '--version',
+  '-A',
+  '--user-agent',
+  '-d',
+  '--data',
+  '--data-raw',
+  '--data-ascii',
+  '--data-urlencode',
+  '--data-binary',
+  '-F',
+  '--form',
+  '-G',
+  '--get',
+  '-H',
+  '--header',
+  '-X',
+  '--request',
+  '-I',
+  '--head',
+  '-T',
+  '--upload-file',
+  '--url',
+  '--basic',
+  '-u',
+  '--user'];
+
+module.exports = supportedOptions;

--- a/src/lib.js
+++ b/src/lib.js
@@ -2,6 +2,7 @@ var commander = require('commander'),
   _ = require('lodash').noConflict(),
   shellQuote = require('../assets/shell-quote'),
   unnecessaryOptions = require('../assets/unnecessaryOptions'),
+  supportedOptions = require('../assets/supportedOptions'),
   program,
 
   curlConverter = {
@@ -262,7 +263,6 @@ var commander = require('commander'),
 
     sanitizeArgs: function(string) {
     // replace -XPOST with -X POST
-      string = string.replace(/(-X)([A-Z]+)/, function (match, x, method) { return x + ' ' + method; });
 
       var argv = shellQuote.parse('node ' + string, function(key) {
           // this is done to prevent converting vars like $id in the curl input to ''
@@ -292,8 +292,17 @@ var commander = require('commander'),
 
           return arg;
 
-        });
-
+        }),
+        i;
+      for (i = 0; i < sanitizedArgs.length; i++) {
+        let arg = sanitizedArgs[i];
+        if (arg.startsWith('-X') && arg !== '-X') {
+          if (!supportedOptions.includes(sanitizedArgs[i - 1])) {
+            sanitizedArgs[i] = '-X';
+            sanitizedArgs.splice(i + 1, 0, arg.slice(2));
+          }
+        }
+      }
       return sanitizedArgs;
     },
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -18,24 +18,20 @@ var commander = require('commander'),
 
       program.version('0.0.1')
         .allowUnknownOption()
-        .usage('[options] <URL ...>')
-        /* eslint-disable max-len */
-        .option('-A, --user-agent <string>', 'An optional user-agent string', null)
-        .option('-d, --data [string]', 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded', collectValues, [])
-        .option('--data-raw [string]', 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded', collectValues, [])
-        .option('--data-ascii [string]', 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded', collectValues, [])
-        .option('--data-urlencode [string]', 'Sends the specified data to the server with type application/x-www-form-urlencoded. application/x-www-form-urlencoded', collectValues, [])
-        .option('--data-binary [string]', 'Data sent as-is', null)
-        .option('-F, --form <name=content>', 'A single form-data field', collectValues, [])
-        .option('-G, --get', 'Forces the request to be sent as GET, with the --data parameters appended to the query string', null)
-        .option('-H, --header [string]', 'Add a header (can be used multiple times)', collectValues, [])
-        .option('-X, --request [string]', 'Specify a custom request mehod to be used', null)
-        .option('-I, --head', 'Forces the request to be sent as HEAD, with the --data parameters appended to the query string', null)
-        .option('-T, --upload-file [string]', 'Forces the request to be sent as PUT with the specified local file to the server', collectValues, [])
-        .option('--url [string]', 'An alternate way to specify the URL', null)
-        .option('--basic', 'Overrides previous auth settings')
-        .option('-u, --user [string]', 'Basic auth ( -u <username:password>)', null);
-      /* eslint-enable */
+        .usage('[options] <URL ...>');
+      supportedOptions.forEach((option) => {
+        var optionStr = '';
+        optionStr += option.short ? `${option.short}, ${option.long}` : option.long;
+        if (option.format) {
+          optionStr += ` ${option.format}`;
+        }
+        if (option.collectValues) {
+          program.option(optionStr, option.description, collectValues, []);
+        }
+        else {
+          program.option(optionStr, option.description, null);
+        }
+      });
     },
 
     trimQuotesFromString: function(str) {
@@ -262,8 +258,6 @@ var commander = require('commander'),
     },
 
     sanitizeArgs: function(string) {
-    // replace -XPOST with -X POST
-
       var argv = shellQuote.parse('node ' + string, function(key) {
           // this is done to prevent converting vars like $id in the curl input to ''
           return '$' + key;
@@ -293,13 +287,19 @@ var commander = require('commander'),
           return arg;
 
         }),
+        validArgs = [],
         i;
+      supportedOptions.forEach((option) => {
+        validArgs.push(option.long);
+        option.short && validArgs.push(option.short);
+      });
       for (i = 0; i < sanitizedArgs.length; i++) {
         let arg = sanitizedArgs[i];
         // check for not exact equal to -X also, as it can be of the form -X POST
         if (arg.startsWith('-X') && arg !== '-X') {
           // suppose arg = -XPOST
-          if (!supportedOptions.includes(sanitizedArgs[i - 1])) {
+          // the arg preceding isn't a commander option(e.g. -H)
+          if (!validArgs.includes(sanitizedArgs[i - 1])) {
             // gets POST from -XPOST
             let method = arg.slice(2);
             // replaces value at index i to -X from -XPOST

--- a/src/lib.js
+++ b/src/lib.js
@@ -296,10 +296,16 @@ var commander = require('commander'),
         i;
       for (i = 0; i < sanitizedArgs.length; i++) {
         let arg = sanitizedArgs[i];
+        // check for not exact equal to -X also, as it can be of the form -X POST
         if (arg.startsWith('-X') && arg !== '-X') {
+          // suppose arg = -XPOST
           if (!supportedOptions.includes(sanitizedArgs[i - 1])) {
+            // gets POST from -XPOST
+            let method = arg.slice(2);
+            // replaces value at index i to -X from -XPOST
             sanitizedArgs[i] = '-X';
-            sanitizedArgs.splice(i + 1, 0, arg.slice(2));
+            // inserts value 'POST' at index i+1
+            sanitizedArgs.splice(i + 1, 0, method);
           }
         }
       }


### PR DESCRIPTION
This PR fixes https://github.com/postmanlabs/postman-app-support/issues/7806

Issue: 
Hardcoded regex match logic for replacing `-XPOST` with `-X POST` was present in`sanitizeArgs` function for the commander to parse the method correctly. This causes problems as if -X is present in header/domain/body, it would replace it too

Fix:
1. Loop through the sanitizedArgs array
2. Find an index i that matches the pattern `-X*` and not exactly equal to `-X`.
3. Look at index i-1, if that is not one of the supported args registered in commander, then it suggests it would be for the method name.
4. Split the arg and get the method name, insert it at index i+1 and set value at index i to be -X.

Example:
```
sanitizedArgs = ['curl', '-XPOST', 'https://domain.com', '-H', 'key: -Xvalue']
```
after the above steps:
```
sanitizedArgs = ['curl', '-X', 'POST', 'https://domain.com', '-H', 'key: -Xvalue']
```
