### PR TITLE
Fix unsuccessful body parsing for --data-urlencode argument

### DIFF
--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -429,4 +429,18 @@ describe('Curl converter should', function() {
     expect(result.method).to.equal('PUT');
     done();
   });
+
+  it('[GitHub #8292]: should import body with --data-urlencode argument', function (done) {
+    var result = Converter.convertCurlToRequest(`curl --location --request POST 'https://httpbin.org/post'
+    --header 'accept: application/json'
+    --header 'Content-Type: application/x-www-form-urlencoded'
+    --data-urlencode 'test=test'`);
+    expect(result.body).to.have.property('mode', 'urlencoded');
+    expect(result.body.urlencoded[0]).to.eql({
+      key: 'test',
+      value: 'test',
+      type: 'text'
+    });
+    done();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/postmanlabs/postman-app-support/issues/8292

Issue:
- `--data-urlencode` param was already registered in commander as an option
- Commander would parse the incoming body correctly and store it in `curlObj.dataUrlencode`
- The code which checks for incoming body did not have a check for `curlObj.datauUrlencode`, thus dropping it completely.

Fix:
- Added check for `curlObj.dataUrlencode` for incoming request body.
- Parse the incoming body stored in `curlObj.dataUrlencode`, add it to request.body with mode set as `urlencoded`

Test:
- Added a regression test with the argument as `--data-urlencode` for the request body