### PR TITLE
Fix an issue where a correct error is thrown if curl string has dangling args

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -317,7 +317,7 @@ var program,
               throw Error('Please check your cURL string for malformed URL');
             }
           }
-          else if (arg.startsWith('$') && arg.length > 1) {
+          else if (_.isFunction(arg.startsWith) && arg.startsWith('$') && arg.length > 1) {
             // removing $ before every arg like $'POST' and
             // converting the arg to 'POST'
             // link of RFC- http://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
@@ -336,7 +336,7 @@ var program,
       for (i = 0; i < sanitizedArgs.length; i++) {
         let arg = sanitizedArgs[i];
         // check for not exact equal to -X also, as it can be of the form -X POST
-        if (arg.startsWith('-X') && arg !== '-X') {
+        if (_.isFunction(arg.startsWith) && arg.startsWith('-X') && arg !== '-X') {
           // suppose arg = -XPOST
           // the arg preceding isn't a commander option(e.g. -H)
           if (!validArgs.includes(sanitizedArgs[i - 1])) {

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -885,4 +885,19 @@ describe('Curl converter should', function() {
       });
     });
   });
+  it('in case where there is a invalid character at the end it should throw an error', function(done) {
+    convert({
+      type: 'string',
+      data: `curl --location --request POST \\
+      "postman-echo.com/post?qwerty=One" \\
+      -H 'Cookie: sails.sid=s%3AGntztErGu9IDGjIBVu2-w7vTipGS3zsf.j9%2BHttqloZ2UJFwtSQbTx6tTTkOz2k6NkNq4NGCaDLI' \\
+      ;`
+    }, function (err, result) {
+      expect(result.result).to.equal(false);
+      expect(result.reason).to.equal(
+        'Only the URL can be provided without an option preceding it.All other inputs must be specified via options.'
+      );
+      done();
+    });
+  });
 });


### PR DESCRIPTION
- For control characters, an object is created with `arg.op`
- Added safe check for method before calling it to avoid `arg.startsWith` error

Fixes this issue
<img width="405" alt="image" src="https://user-images.githubusercontent.com/3478831/215432620-c02d84ab-369a-4655-b923-2bdfd6294a85.png">