### PR TITLE
Fixed issue where cURL with no specific method defined for formdata type of body were not converted correctly.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get Code
+        uses: actions/checkout@v3
+      - name: Setup Node JS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm run test

--- a/src/lib.js
+++ b/src/lib.js
@@ -82,7 +82,8 @@ var program,
       // checking if the user has mentioned any of these (-d, --data, --data-raw
       // --data-binary, --data-ascii) in curl command
       else if (curlObj.data.length > 0 || curlObj.dataAscii.length > 0 ||
-         curlObj.dataUrlencode.length > 0 || curlObj.dataRaw.length > 0 || curlObj.dataBinary) {
+         curlObj.dataUrlencode.length > 0 || curlObj.dataRaw.length > 0 ||
+         curlObj.dataBinary || curlObj.form.length > 0) {
         return 'POST';
       }
       // set method to GET if no param is present
@@ -574,7 +575,8 @@ var program,
           dataRawString,
           dataAsciiString,
           dataUrlencode,
-          formData;
+          formData,
+          isMethodGuessed = false;
 
         try {
           sanitizedArgs = this.sanitizeArgs(cleanedCurlString);
@@ -601,6 +603,7 @@ var program,
         // if method is not given in the curl command
         if (!curlObj.request) {
           curlObj.request = this.getRequestMethod(curlObj);
+          isMethodGuessed = true;
         }
 
         curlObj.request = this.trimQuotesFromString(curlObj.request);
@@ -685,6 +688,12 @@ var program,
           });
           request.body.mode = 'formdata';
           request.body.formdata = this.parseFormBoundryData(formData, content_type);
+
+          /**
+           * As we are parsing raw args here to detect form-data body, make sure we are also
+           * defining method if not already defined in cURL
+           */
+          (!_.isEmpty(request.body.formdata) && isMethodGuessed) && (request.method = 'POST');
         }
 
         if (request.body.mode === 'formdata') {


### PR DESCRIPTION
## Issue:
When users were importing cURL with formdata body and no specific HTTP method was not mentioned in cURL, imports were not generating correctly. i.e. method was defined as `GET` in such cases, resulting in Postman not showing body at all.

## RCA:
Issue was happening due to request method determination logic not considering form-data body while defining `POST` methods. This was happening for both following mentioned cases.
- When `--form` param was specifically mentioned
- When form-data boundaries were used to define form-data body

## Fix:
We'll be correctly assigning method in such cases to make sure that imported Postman request correctly displays request body.
