### PR TITLE
Fixed an issue where cURL with comments described was converted incorrectly.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -444,8 +444,11 @@ var program,
         }
         /* eslint-enable */
       }
-      else {
+      else if (_.isString(curlObj.args[0])) {
         this.requestUrl = curlObj.args[0];
+      }
+      else {
+        throw new Error('Could not detect the URL from cURL. Please make sure it\'s a valid cURL');
       }
     },
 
@@ -597,6 +600,12 @@ var program,
           sanitizedArgs = this.sanitizeArgs(cleanedCurlString);
           curlObj = program.parse(sanitizedArgs);
         }
+
+        // Filter out comments from Args
+        curlObj.args = _.filter(curlObj.args, (arg) => {
+          // Each arg should be string itself, for comment we receive an object from parser
+          return !(typeof arg === 'object' && typeof arg.comment === 'string');
+        });
 
         this.headerPairs = {};
 

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -49,6 +49,18 @@ describe('Curl converter should', function() {
     });
   });
 
+  it('throw an error for a cURL without URL defined correctly', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl -X POST -H \'Content-type: application/json\' #{reply_url} --data \'#{response.to_json}\''
+    }, function (err, result) {
+      expect(result.result).to.equal(false);
+      expect(result.reason).to.equal('Error while parsing cURL: Could not identify the URL.' +
+       ' Please use the --url option.');
+      done();
+    });
+  });
+
   it('[Github #7390]: set request URL correctly irrespective of where it is mentioned', function (done) {
     convert({
       type: 'string',
@@ -155,6 +167,23 @@ describe('Curl converter should', function() {
     convert({
       type: 'string',
       data: 'curl --request GET --url http://www.google.com'
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+
+      expect(result.output.length).to.equal(1);
+      expect(result.output[0].type).to.equal('request');
+
+      var request = result.output[0].data;
+      expect(request.method).to.equal('GET');
+      expect(request.url).to.equal('http://www.google.com');
+      done();
+    });
+  });
+
+  it('convert a simple request with comment at the end correctly', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request GET --url http://www.google.com #comment1'
     }, function (err, result) {
       expect(result.result).to.equal(true);
 


### PR DESCRIPTION
## Overview

This PR fixes issue where for certain cURL were converted incorrectly. For example, below cURL imported successfully with incorrect URL and name being object rather than failing as it's invalid cURL. i.e. executing this command  will provide following error in bash.

```
➜  ~ curl -X POST -H 'Content-type: application/json' #{reply_url} --data '#{response.to_json}'
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```

## RCA
issue was happening due to incorrect handling of `curlObj.args` whenever comments were present. We're simply assigning `curlObj.args[0]` directly as a request URL. Which created object for URL which is incorrect as it should be string.

## Fix
We'll be filtering out any comments found in the `curlObj.args` and also making sure we only assign string values to request URL.
