### PR TITLE
Fixed an issue where request generation failed for certain bash operators.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -452,6 +452,7 @@ var program,
       else if (curlObj.args.length > 0) {
         let argStr = typeof curlObj.url === 'string' ? curlObj.url : '';
 
+        // eslint-disable-next-line consistent-return
         _.forEach(curlObj.args, (arg, index) => {
           const previousArgOp = _.get(curlObj.args, `${index - 1}.op`, ''),
             shouldAddCurrentArg = index === 0 || allowedOperators.includes(previousArgOp);

--- a/src/lib.js
+++ b/src/lib.js
@@ -453,16 +453,25 @@ var program,
         let argStr = typeof curlObj.url === 'string' ? curlObj.url : '';
 
         _.forEach(curlObj.args, (arg, index) => {
-          if (typeof arg === 'string') {
-            const previousArgOp = _.get(curlObj.args, `${index - 1}.op`, ''),
-              shouldAddCurrentArg = index === 0 || allowedOperators.includes(previousArgOp);
+          const previousArgOp = _.get(curlObj.args, `${index - 1}.op`, ''),
+            shouldAddCurrentArg = index === 0 || allowedOperators.includes(previousArgOp);
 
+          if (typeof arg === 'string' && shouldAddCurrentArg) {
             /**
              * Add current string arg only if previous arg is an allowed op.
              * For URL like "hello.com/<id>", as "<" and ">" are treated as bash operators,
              * we'll add such operator and next arg that was split up by it in URL
              */
-            shouldAddCurrentArg && (argStr += (previousArgOp + arg));
+            argStr += arg;
+          }
+          else if (typeof arg === 'object' && allowedOperators.includes(arg.op)) {
+            argStr += arg.op;
+          }
+          else {
+            /**
+             * Stop adding more args as soon as we know that args are not split by allowed operators.
+             */
+            return false;
           }
         });
         this.requestUrl = argStr;

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -1283,4 +1283,39 @@ describe('Curl converter should', function() {
       done();
     });
   });
+
+  describe('It should correctly generate request for cURL with various postman id formats in URL', function() {
+
+    it('containing path variable with ":" character', function(done) {
+      convert({
+        type: 'string',
+        data: `curl https://httpbin.org/team/:teamId/user/:userId \
+        -H 'authority: httpbin.org'
+        `
+      }, function (err, result) {
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.equal('request');
+        expect(result.output[0].data.url).to.equal('https://httpbin.org/team/:teamId/user/:userId');
+        expect(result.output[0].data.method).to.equal('GET');
+        done();
+      });
+    });
+
+    it('containing collection/environment variable in URL', function(done) {
+      convert({
+        type: 'string',
+        data: `curl {{baseUrl}}/user/{{userId}} \
+        -H 'authority: httpbin.org'
+        `
+      }, function (err, result) {
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.equal('request');
+        expect(result.output[0].data.url).to.equal('{{baseUrl}}/user/{{userId}}');
+        expect(result.output[0].data.method).to.equal('GET');
+        done();
+      });
+    });
+  });
 });

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -1252,4 +1252,35 @@ describe('Curl converter should', function() {
       done();
     });
   });
+
+  it('It should correctly generate request for cURL with allowed operators not in URL correctly', function(done) {
+    convert({
+      type: 'string',
+      data: `curl 'https://httpbin.org/anything' \
+      -H 'authority: httpbin.org' \
+      -H "user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) (KHTML, like Gecko) Chrome/109.0.0.0" \
+      -H 'accept: application/json, text/plain, */*' \
+      -H 'content-type: application/json' \
+      --data "{\"context\":{\"client\":{\"hl\":\"en\"}},\"state\":true}"
+    `
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output.length).to.equal(1);
+      expect(result.output[0].type).to.equal('request');
+      expect(result.output[0].data.url).to.equal('https://httpbin.org/anything');
+      expect(result.output[0].data.method).to.equal('POST');
+
+      const headerArr = result.output[0].data.header;
+      expect(headerArr.length).to.equal(4);
+      expect(headerArr[0].key).to.equal('authority');
+      expect(headerArr[0].value).to.equal('httpbin.org');
+      expect(headerArr[1].key).to.equal('user-agent');
+      expect(headerArr[1].value).to.equal('Mozilla/5.0 (Windows NT 10.0; Win64; x64) (KHTML, like Gecko) Chrome/109.0.0.0');
+      expect(headerArr[2].key).to.equal('accept');
+      expect(headerArr[2].value).to.equal('application/json, text/plain, */*');
+      expect(headerArr[3].key).to.equal('content-type');
+      expect(headerArr[3].value).to.equal('application/json');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Overview

The current convert API failed to generate requests correctly for certain cURL containing bash operators like `<` and `>`. For example, below cURL

```
curl --request GET \
  --url https://hello.com/company/<companyId>/team \
  --header "Authorization: Basic aGVsbG86d29ybGQ="
```

## RCA

When such operators were used in the URL, the cURL parser (commander) assigned `<` and `>` as separate arg. This resulted in an Error as we're throwing an error when there were more than 1 args.

## Fix

We'll be now also using multiple arguments from parsed cURL and constructing URLs based on allowed operators. Instead of throwing an error, we'll now handle such cURLs gracefully and use the first constructed arg as a URL. This constructed URL will contain allowed operators along with strings that were split by them.