### PR TITLE
handle url encoded body containing `+` character

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -309,8 +309,8 @@ var program,
         }
 
         if (toDecodeUri) {
-          key = decodeURIComponent(key);
-          val = decodeURIComponent(val);
+          key = decodeURIComponent(key.replace(/\+/g, '%20'));
+          val = decodeURIComponent(val.replace(/\+/g, '%20'));
         }
 
         _.assign(paramObj, { key, value: val });

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -510,6 +510,26 @@ describe('Curl converter should', function() {
     done();
   });
 
+  it('should import body data with --data-raw argument containing "+"', function (done) {
+    var result = Converter.convertCurlToRequest(`curl --location --request POST "https://sample.com"
+    --header "Content-Type: application/x-www-form-urlencoded"
+    --data-raw 'a=hello+world&key+with+space=hello%20world'`);
+
+    expect(result.body).to.have.property('mode', 'urlencoded');
+    expect(result.body.urlencoded[0]).to.eql({
+      key: 'a',
+      value: 'hello world',
+      type: 'text'
+    });
+    expect(result.body.urlencoded[1]).to.eql({
+      key: 'key with space',
+      value: 'hello world',
+      type: 'text'
+    });
+
+    done();
+  });
+
   it('[GitHub #7806]: should parse -X method correctly', function (done) {
     var result = Converter.convertCurlToRequest('curl -H "X-XSRF-Token: token_value" https://domain.com');
     expect(result.method).to.eql('GET');


### PR DESCRIPTION
Both `+` and `%20` should be treated as spaces but the `+` was not being handled, meaning if you imported a curl command into postman postman would then make the request containing a literal `+` instead of space. Took a while to debug 😆 