### PR TITLE
Assign user errors when curl conversion fails due to handled cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+-   Assigned user errors for various handled errors
+
 ## [v1.6.0] - 2023-04-17
 
 ### Added

--- a/src/UserError.js
+++ b/src/UserError.js
@@ -1,0 +1,15 @@
+/**
+ * constructor userError
+ * @constructor
+ * @param {*} message errorMessage
+ * @param {*} data additional data to be reported
+ */
+class UserError extends Error {
+  constructor(message, data) {
+    super(message);
+    this.name = 'UserError';
+    this.data = data || {};
+  }
+}
+
+module.exports = UserError;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,14 @@
+/* eslint-disable max-len */
+
+module.exports = {
+  USER_ERRORS: {
+    INVALID_FORMAT: 'Invalid format for cURL.',
+    METHOD_NOT_SUPPORTED: (_, method) => { return `The method ${method} is not supported.`; },
+    UNABLE_TO_PARSE_HEAD_AND_DATA: 'Unable to parse: Both (--head/-I) and (-d/--data/--data-raw/--data-binary/--data-ascii/--data-urlencode) are not supported.',
+    UNABLE_TO_PARSE_NO_URL: 'Unable to parse: Could not identify the URL. Please use the --url option.',
+    CANNOT_DETECT_URL: 'Could not detect the URL from cURL. Please make sure it\'s a valid cURL.',
+    INPUT_WITHOUT_OPTIONS: 'Only the URL can be provided without an option preceding it. All other inputs must be specified via options.',
+    MALFORMED_URL: 'Please check your cURL string for malformed URL.'
+  }
+};
+

--- a/src/convert.js
+++ b/src/convert.js
@@ -15,7 +15,8 @@ module.exports = function (input, cb) {
     if (result.error) {
       return cb(null, {
         result: false,
-        reason: result.error
+        error: result.error,
+        reason: result.error.message
       });
     }
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -15,7 +15,7 @@ module.exports = function (input, cb) {
     if (result.error) {
       return cb(null, {
         result: false,
-        reason: result.error.message
+        reason: result.error
       });
     }
 

--- a/src/getMetaData.js
+++ b/src/getMetaData.js
@@ -15,6 +15,7 @@ module.exports = function (input, cb) {
     if (result.error) {
       return cb(null, {
         result: false,
+        error: result.error,
         reason: result.error.message
       });
     }

--- a/src/lib.js
+++ b/src/lib.js
@@ -5,6 +5,7 @@ const commander = require('commander'),
   unnecessaryOptions = require('../assets/unnecessaryOptions'),
   supportedOptions = require('../assets/supportedOptions'),
   UserError = require('./UserError'),
+  { USER_ERRORS } = require('./constants'),
   formDataOptions = ['-d', '--data', '--data-raw', '--data-binary', '--data-ascii'],
   allowedOperators = ['<', '>', '(', ')'];
 
@@ -119,7 +120,7 @@ var program,
 
         if (validMethods.indexOf(curlObj.request.toUpperCase()) === -1) {
         // the method is still not valid
-          throw new UserError('The method ' + curlObj.request + ' is not supported');
+          throw new UserError(USER_ERRORS.METHOD_NOT_SUPPORTED`${curlObj.request}`);
         }
       }
 
@@ -128,8 +129,7 @@ var program,
       if ((curlObj.data.length > 0 || curlObj.dataAscii.length > 0 ||
          curlObj.dataBinary || curlObj.dataUrlencode.length > 0) &&
             curlObj.head && !curlObj.get) {
-        throw new UserError('Unable to parse: Both (--head/-I) and' +
-         ' (-d/--data/--data-raw/--data-binary/--data-ascii/--data-urlencode) are not supported');
+        throw new UserError(USER_ERRORS.UNABLE_TO_PARSE_HEAD_AND_DATA);
       }
 
       /**
@@ -138,8 +138,7 @@ var program,
        * once it fails here using convertForCMDFormat()
        */
       if (curlObj.args.length > 1 && _.includes(curlObj.args, '^')) {
-        throw new UserError('Only the URL can be provided without an option preceding it.' +
-         ' All other inputs must be specified via options.');
+        throw new UserError(USER_ERRORS.INPUT_WITHOUT_OPTIONS);
       }
     },
 
@@ -376,7 +375,7 @@ var program,
               inCorrectlyFormedcURLRegex2 = /(\w+=\w+&?)/g; // checks - foo?bar=1&baz=2
 
             if (string.match(inCorrectlyFormedcURLRegex1) || string.match(inCorrectlyFormedcURLRegex2)) {
-              throw new UserError('Please check your cURL string for malformed URL');
+              throw new UserError(USER_ERRORS.MALFORMED_URL);
             }
           }
           else if (_.isFunction(arg.startsWith) && arg.startsWith('$') && arg.length > 1) {
@@ -429,7 +428,7 @@ var program,
       catch (e) {
         if (e.message === 'process.exit is not a function') {
           // happened because of
-          return { error: new UserError('Invalid format for cURL.') };
+          return { error: new UserError(USER_ERRORS.INVALID_FORMAT) };
         }
         return { error: e };
       }
@@ -453,7 +452,7 @@ var program,
             }
           }
           catch (e) {
-            throw new UserError('Unable to parse: Could not identify the URL. Please use the --url option.');
+            throw new UserError(USER_ERRORS.UNABLE_TO_PARSE_NO_URL);
           }
         }
         /* eslint-enable */
@@ -487,7 +486,7 @@ var program,
         this.requestUrl = argStr;
       }
       else {
-        throw new Error('Could not detect the URL from cURL. Please make sure it\'s a valid cURL');
+        throw new UserError(USER_ERRORS.CANNOT_DETECT_URL);
       }
     },
 
@@ -674,7 +673,7 @@ var program,
           return this.validate(curlString, false);
         }
 
-        return { result: false, reason: e };
+        return { result: false, reason: e.message, error: e };
       }
     },
 
@@ -804,7 +803,7 @@ var program,
           }
         }
         if (e.message === 'process.exit is not a function') {
-          return { error: new UserError('Invalid format for cURL.') };
+          return { error: new UserError(USER_ERRORS.INVALID_FORMAT) };
         }
         return { error: e };
       }

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -12,8 +12,9 @@ describe('validate', function () {
   it('return false result for malformed curl snippet', function (done) {
     const result = validate('curl --request');
     expect(result.result).to.equal(false);
-    expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
+    expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
       ' Please use the --url option.');
+    expect(result.error).to.have.property('message', result.reason);
     done();
   });
 });
@@ -41,6 +42,7 @@ describe('getMetaData', function () {
       expect(result.result).to.equal(false);
       expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
         ' Please use the --url option.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
@@ -53,6 +55,7 @@ describe('getMetaData', function () {
       expect(result.result).to.equal(false);
       expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
         ' Please use the --url option.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
@@ -66,8 +69,9 @@ describe('Curl converter should', function() {
       data: 'curl --request'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
        ' Please use the --url option.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
@@ -78,12 +82,24 @@ describe('Curl converter should', function() {
       data: 'curl --location --request POST --header "Content-Type: application/json"'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
         ' Please use the --url option.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
 
+  it('throw an error when an invalid method is specificied', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request INVALIDMETHOD --url http://www.google.com'
+    }, function (err, result) {
+      expect(result.result).to.equal(false);
+      expect(result.reason).to.equal('The method INVALIDMETHOD is not supported.');
+      expect(result.error).to.have.property('message', result.reason);
+      done();
+    });
+  });
 
   it('throw an error for a cURL without URL defined correctly', function (done) {
     convert({
@@ -91,8 +107,9 @@ describe('Curl converter should', function() {
       data: 'curl -X POST -H \'Content-type: application/json\' #{reply_url} --data \'#{response.to_json}\''
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
        ' Please use the --url option.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
@@ -246,8 +263,9 @@ describe('Curl converter should', function() {
       data: 'curl -I http://example.com -d "a=b"'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.have.property('message').equal('Unable to parse: Both (--head/-I) and' +
-       ' (-d/--data/--data-raw/--data-binary/--data-ascii/--data-urlencode) are not supported');
+      expect(result.reason).to.equal('Unable to parse: Both (--head/-I) and' +
+       ' (-d/--data/--data-raw/--data-binary/--data-ascii/--data-urlencode) are not supported.');
+      expect(result.error).to.have.property('message', result.reason);
       done();
     });
   });
@@ -937,7 +955,8 @@ describe('Curl converter should', function() {
         test?bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.equal('Please check your cURL string for malformed URL.');
+        expect(result.error).to.have.property('message', result.reason);
         done();
       });
     });
@@ -951,7 +970,8 @@ describe('Curl converter should', function() {
         bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.equal('Please check your cURL string for malformed URL.');
+        expect(result.error).to.have.property('message', result.reason);
         done();
       });
     });
@@ -966,7 +986,8 @@ describe('Curl converter should', function() {
         "test.com/?bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.equal('Please check your cURL string for malformed URL.');
+        expect(result.error).to.have.property('message', result.reason);
         done();
       });
     });

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -12,7 +12,7 @@ describe('validate', function () {
   it('return false result for malformed curl snippet', function (done) {
     const result = validate('curl --request');
     expect(result.result).to.equal(false);
-    expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
+    expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
       ' Please use the --url option.');
     done();
   });
@@ -66,7 +66,7 @@ describe('Curl converter should', function() {
       data: 'curl --request'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
        ' Please use the --url option.');
       done();
     });
@@ -78,7 +78,7 @@ describe('Curl converter should', function() {
       data: 'curl --location --request POST --header "Content-Type: application/json"'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
         ' Please use the --url option.');
       done();
     });
@@ -91,7 +91,7 @@ describe('Curl converter should', function() {
       data: 'curl -X POST -H \'Content-type: application/json\' #{reply_url} --data \'#{response.to_json}\''
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
+      expect(result.reason).to.have.property('message').equal('Unable to parse: Could not identify the URL.' +
        ' Please use the --url option.');
       done();
     });
@@ -246,7 +246,7 @@ describe('Curl converter should', function() {
       data: 'curl -I http://example.com -d "a=b"'
     }, function (err, result) {
       expect(result.result).to.equal(false);
-      expect(result.reason).to.equal('Unable to parse: Both (--head/-I) and' +
+      expect(result.reason).to.have.property('message').equal('Unable to parse: Both (--head/-I) and' +
        ' (-d/--data/--data-raw/--data-binary/--data-ascii/--data-urlencode) are not supported');
       done();
     });
@@ -937,7 +937,7 @@ describe('Curl converter should', function() {
         test?bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
         done();
       });
     });
@@ -951,7 +951,7 @@ describe('Curl converter should', function() {
         bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
         done();
       });
     });
@@ -966,7 +966,7 @@ describe('Curl converter should', function() {
         "test.com/?bar=1&baz=2`
       }, function (err, result) {
         expect(result.result).to.equal(false);
-        expect(result.reason).to.equal('Please check your cURL string for malformed URL');
+        expect(result.reason).to.have.property('message').equal('Please check your cURL string for malformed URL');
         done();
       });
     });


### PR DESCRIPTION
This PR
- Adds a new error type `UserError`
- Returns all known handled error scenarios wrapped in `UserError`
- Adds an error object to the object returned in callback as `error`
- Moves all known error messages to a constants file

![Screenshot 2023-06-21 at 16 31 36](https://github.com/postmanlabs/curl-to-postman/assets/3478831/012efaef-d9da-435c-a29a-bf506ffb9c6b)
