### PR TITLE
Fixed an issue where GraphQL bodies were not generated correctly.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -705,6 +705,7 @@ var program,
     identifyGraphqlRequest: function (dataString, contentType) {
       try {
         const rawDataObj = _.attempt(JSON.parse, this.escapeJson(dataString));
+
         if (contentType === 'application/json' && rawDataObj && !_.isError(rawDataObj)) {
           if (!_.has(rawDataObj, 'query') || !_.isString(rawDataObj.query)) {
             return { result: false };
@@ -721,17 +722,14 @@ var program,
             if (!_.isString(rawDataObj.operationName)) {
               return { result: false };
             }
+            delete rawDataObj.operationName;
           }
-          else {
-            rawDataObj.operationName = '';
-          }
-          if (_.keys(rawDataObj).length === 3) {
+          if (_.keys(rawDataObj).length === 2) {
             const graphqlVariables = JSON.stringify(rawDataObj.variables, null, 2);
             return {
               result: true,
               graphql: {
                 query: rawDataObj.query,
-                operationName: rawDataObj.operationName,
                 variables: graphqlVariables === '{}' ? '' : graphqlVariables
               }
             };

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -743,6 +743,18 @@ describe('Curl converter should', function() {
     done();
   });
 
+  it('[Github #12349]: should correctly convert graphql queries without operationName', function(done) {
+    var result = Converter.convertCurlToRequest(`curl --location 'https://spacex-production.up.railway.app' \\
+    --header 'Content-Type: application/json' \\
+    --data '{"query":"query getCompanyData {\r\n    company {\r\n        ceo\r\n    }\r\n}","variables":{}}'`);
+
+    expect(result.body).to.have.property('mode', 'graphql');
+    expect(result.body.graphql.query).to.eql('query getCompanyData {\r\n    company {\r\n        ceo\r\n    }\r\n}');
+    expect(result.body.graphql.variables).to.eql('');
+    expect(result.body.graphql).to.not.have.property('operationName');
+    done();
+  });
+
   describe('[Github #8843]: It should recognize non-apostrophed ("...") url with multi-param', function() {
     it('in case where there is multiple params with & in between in the url (https)', function(done) {
       convert({


### PR DESCRIPTION
## Overview

This PR fixes issue https://github.com/postmanlabs/postman-app-support/issues/12349.

For certain cURL imported GraphQL requests, sending requests resulted in incorrect an response. Even though mentioning same data in the newly created request and sending this new request was working correctly with the expected response.

## RCA

The issue was happening due to generated Postman request having incorrect `operationName` field for body type graphql. In Postman, we don't have a way to set `operationName` field yet. So users can not change this and in this case, having it as empty meant server responding with incorrect response.

## Fix

We'll not be setting this `operationName` field at all since Postman hasn't exposed the use of it yet. However, it will be considered towards the detection of graphql body as an optional param.