### PR TITLE
Fixed an issue where certain character after $ were omitted while importing curl

### DIFF
--- a/assets/shell-quote.js
+++ b/assets/shell-quote.js
@@ -44,7 +44,7 @@ for (var i = 0; i < 4; i++) {
  */
 const unicodeRegExp = /\\x([0-9A-Fa-f]{2})|\\u([0-9A-Fa-f]{4})|\\u\{([0-9A-Fa-f]{1,6})\}|\\([\s\S])/gm;
 
-// Single character escape sequence mapping to corresponding character 
+// Single character escape sequence mapping to corresponding character
 const escapeCharMap = {
   'b': '\b',
   'f': '\f',
@@ -210,7 +210,6 @@ function parse(s, env, opts) {
       }
       else if (/[*@#?$!_\-]/.test(s.charAt(i))) {
         varname = s.charAt(i);
-        i += 1;
       }
       else {
         varend = s.substr(i).match(/[^\w\d_]/);

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -663,6 +663,13 @@ describe('Curl converter should', function() {
     done();
   });
 
+  it('[GitHub #11888]: should correctly handle characters after `$`', function (done) {
+    var result = Converter.convertCurlToRequest('curl -X GET "https://alextest.com" -H "5f005074: [jKanrLih$!]SooCV5u)aI!pt9"');
+
+    expect(result.header).to.eql([{ key: '5f005074', value: '[jKanrLih$!]SooCV5u)aI!pt9' }]);
+    done();
+  });
+
   it('[GitHub #7895]: should correctly handle raw form data with boundry separated body', function (done) {
     var result = Converter.convertCurlToRequest(`curl 'https://httpbin.org/post'
     -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7oJTsSWYoA2LdaPx' --data $'` +


### PR DESCRIPTION
## Overview
Fix for the issue:- https://github.com/postmanlabs/postman-app-support/issues/11888

The user was unable to import the string below correctly:- 
`curl -X GET "https://alextest.com/" -H "5f005074: [jKanrLih$!]SooCV5u)aI!pt9"`
The output is coming out to be 
```
{
  method: 'GET',
  name: 'https://alextest.com',
  url: 'https://alextest.com',
  header: [ { key: '5f005074', value: '[jKanrLih$!SooCV5u)aI!pt9' } ],
  body: {},
  description: 'Generated from a curl request: \n' +
    'curl -X GET \\"https://alextest.com\\" -H \\"5f005074: [jKanrLih$!]SooCV5u)aI!pt9\\"'
}
```

As you can see the character `]` is missing in the header value.

## RCA
When a curl string has `$` char, and the next character matches `/[*@#?$!_\-]/`, the character after that skipped because the index was incremented seemingly unnecessarily.

## Fix
Remove unnecessary index increment.

##  Output
The output after fix is correct and as expected.
```
{
  method: 'GET',
  name: 'https://alextest.com',
  url: 'https://alextest.com',
  header: [ { key: '5f005074', value: '[jKanrLih$!]SooCV5u)aI!pt9' } ],
  body: {},
  description: 'Generated from a curl request: \n' +
    'curl -X GET \\"https://alextest.com\\" -H \\"5f005074: [jKanrLih$!]SooCV5u)aI!pt9\\"'
}
```