### PR TITLE
Added support for supporting -b/--cookies arg for mentioning Cookies.

### DIFF
--- a/assets/supportedOptions.js
+++ b/assets/supportedOptions.js
@@ -106,6 +106,13 @@ let supportedOptions = [
     description: 'Username and password for server authentication',
     format: '[string]',
     collectValues: false
+  },
+  {
+    short: '-b',
+    long: '--cookie',
+    description: 'Specifies cookies to be used in the format "NAME=VALUE" or a file to read cookies from',
+    format: '[string]',
+    collectValues: true
   }
 ];
 module.exports = supportedOptions;

--- a/src/lib.js
+++ b/src/lib.js
@@ -18,7 +18,8 @@ const commander = require('commander'),
     [REQUEST_BODY_LANGUAGE_JAVASCRIPT]: /^(text|application)\/(\S+\+)?javascript/,
     [REQUEST_BODY_LANGUAGE_XML]: /^(text|application)\/(\S+\+)?xml/,
     [REQUEST_BODY_LANGUAGE_HTML]: /^text\/html/
-  };
+  },
+  ALLOWED_DUPLICATE_HEADERS = ['cookie'];
 
 var program,
 
@@ -177,6 +178,13 @@ var program,
         });
       }
 
+      // If any cookies are added under -b or --cookie arg, add them as Cookie header
+      if (curlObj.cookie && Array.isArray(curlObj.cookie)) {
+        curlObj.cookie.forEach((cookieVal) => {
+          headerArray.push('Cookie: ' + this.trimQuotesFromString(cookieVal));
+        });
+      }
+
       if (headerArray === null || headerArray.length === 0) {
         return retVal;
       }
@@ -210,7 +218,7 @@ var program,
         value = thisHeader.substring(keyIndex + 1, thisHeader.length).trim();
         /* eslint-enable */
 
-        if (this.headerPairs.hasOwnProperty(key)) {
+        if (this.headerPairs.hasOwnProperty(key) && !ALLOWED_DUPLICATE_HEADERS.includes(key.toLowerCase())) {
         // don't add the same header twice
           continue;
         }

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -1444,4 +1444,84 @@ describe('Curl converter should', function() {
       });
     });
   });
+
+  describe('It should correctly generate request with cookie header', function() {
+    it('containing -b option', function(done) {
+      convert({
+        type: 'string',
+        data: `curl 'https://httpbin.org/anything' \
+        -b 'dashboard_beta=yes; postman-beta.track=default' \
+        -H 'authority: httpbin.org'
+        --data "{\"context\":{\"client\":{\"hl\":\"en\"}},\"state\":true}"
+      `
+      }, function (err, result) {
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.equal('request');
+        expect(result.output[0].data.url).to.equal('https://httpbin.org/anything');
+        expect(result.output[0].data.method).to.equal('POST');
+
+        const headerArr = result.output[0].data.header;
+        expect(headerArr.length).to.equal(2);
+        expect(headerArr[0].key).to.equal('authority');
+        expect(headerArr[0].value).to.equal('httpbin.org');
+        expect(headerArr[1].key).to.equal('Cookie');
+        expect(headerArr[1].value).to.equal('dashboard_beta=yes; postman-beta.track=default');
+        done();
+      });
+    });
+
+    it('containing --cookie option', function(done) {
+      convert({
+        type: 'string',
+        data: `curl 'https://httpbin.org/anything' \
+        --cookie 'dashboard_beta=yes; postman-beta.track=default' \
+        -H 'authority: httpbin.org'
+        --data "{\"context\":{\"client\":{\"hl\":\"en\"}},\"state\":true}"
+      `
+      }, function (err, result) {
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.equal('request');
+        expect(result.output[0].data.url).to.equal('https://httpbin.org/anything');
+        expect(result.output[0].data.method).to.equal('POST');
+
+        const headerArr = result.output[0].data.header;
+        expect(headerArr.length).to.equal(2);
+        expect(headerArr[0].key).to.equal('authority');
+        expect(headerArr[0].value).to.equal('httpbin.org');
+        expect(headerArr[1].key).to.equal('Cookie');
+        expect(headerArr[1].value).to.equal('dashboard_beta=yes; postman-beta.track=default');
+        done();
+      });
+    });
+
+    it('containing multiple cookies', function(done) {
+      convert({
+        type: 'string',
+        data: `curl 'https://httpbin.org/anything' \
+        -b 'dashboard_beta=yes; postman-beta.track=default' \
+        -b 'name=JohnDoe' \
+        -H 'authority: httpbin.org' \
+        --data "{\"context\":{\"client\":{\"hl\":\"en\"}},\"state\":true}"
+      `
+      }, function (err, result) {
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.equal('request');
+        expect(result.output[0].data.url).to.equal('https://httpbin.org/anything');
+        expect(result.output[0].data.method).to.equal('POST');
+
+        const headerArr = result.output[0].data.header;
+        expect(headerArr.length).to.equal(3);
+        expect(headerArr[0].key).to.equal('authority');
+        expect(headerArr[0].value).to.equal('httpbin.org');
+        expect(headerArr[1].key).to.equal('Cookie');
+        expect(headerArr[1].value).to.equal('dashboard_beta=yes; postman-beta.track=default');
+        expect(headerArr[2].key).to.equal('Cookie');
+        expect(headerArr[2].value).to.equal('name=JohnDoe');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Overview

Fixes: https://github.com/postmanlabs/postman-app-support/issues/13455

This PR adds support for `-b` and `--cookie` argument in cURL imported. We'll now be creating Cookie header for each mentioned `-b` or `--cookie` argument to support correct import.