### PR TITLE
Allow cURL import with empty URL

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -462,12 +462,26 @@ var program,
     getRequestUrl: function(curlObj) {
       this.requestUrl = '';
       if (curlObj.args.length === 0) {
-        if (curlObj.url) {
+
+        if (typeof curlObj.url === 'string') {
         // url is populated if there's no unknown option
-          this.requestUrl = curlObj.url;
+          this.requestUrl = curlObj.url.trim();
         }
         else {
         // if there is an unknown option, we have to take it from the rawArgs
+          const rawArgs = Array.isArray(curlObj.rawArgs) ? curlObj.rawArgs : [],
+            urlArgIndex = rawArgs.lastIndexOf('--url'),
+            hasUrlOption = urlArgIndex > -1,
+            explicitUrlValue = rawArgs[urlArgIndex + 1],
+            normalizedExplicitUrl = typeof explicitUrlValue === 'string' ? explicitUrlValue.trim() : '',
+            hasUrlArgument = Boolean(normalizedExplicitUrl && !normalizedExplicitUrl.startsWith('-'));
+
+          // Allow conversion to an empty-URL request when --url is present without a usable URL argument.
+          if (hasUrlOption && !hasUrlArgument) {
+            this.requestUrl = '';
+            return;
+          }
+
           try {
             this.requestUrl = curlObj.rawArgs.slice(-1)[0];
             /* eslint-disable max-depth */

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -17,6 +17,30 @@ describe('validate', function () {
     expect(result.error).to.have.property('message', result.reason);
     done();
   });
+
+  it('return true result for explicit empty --url value', function (done) {
+    const result = validate('curl --request GET --url \'\'');
+    expect(result.result).to.equal(true);
+    done();
+  });
+
+  it('return true result for --url without value', function (done) {
+    const result = validate('curl --request GET --url');
+    expect(result.result).to.equal(true);
+    done();
+  });
+
+  it('return true result for --url followed by another option', function (done) {
+    const result = validate('curl --url --request GET');
+    expect(result.result).to.equal(true);
+    done();
+  });
+
+  it('return true result for whitespace-only --url value', function (done) {
+    const result = validate('curl --request GET --url \'     \'');
+    expect(result.result).to.equal(true);
+    done();
+  });
 });
 
 describe('getMetaData', function () {
@@ -59,6 +83,54 @@ describe('getMetaData', function () {
       done();
     });
   });
+
+  it('return true result for explicit empty --url value', function (done) {
+    getMetaData({
+      type: 'string',
+      data: 'curl --request GET --url \'\''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.name).to.equal('');
+      expect(result.output[0].data).to.equal('');
+      done();
+    });
+  });
+
+  it('return true result for --url without value', function (done) {
+    getMetaData({
+      type: 'string',
+      data: 'curl --request GET --url'
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.name).to.equal('');
+      expect(result.output[0].data).to.equal('');
+      done();
+    });
+  });
+
+  it('return true result for --url followed by another option', function (done) {
+    getMetaData({
+      type: 'string',
+      data: 'curl --url --request GET'
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.name).to.equal('');
+      expect(result.output[0].data).to.equal('');
+      done();
+    });
+  });
+
+  it('return true result for whitespace-only --url value', function (done) {
+    getMetaData({
+      type: 'string',
+      data: 'curl --request GET --url \'     \''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.name).to.equal('');
+      expect(result.output[0].data).to.equal('');
+      done();
+    });
+  });
 });
 
 describe('Curl converter should', function() {
@@ -85,6 +157,70 @@ describe('Curl converter should', function() {
       expect(result.reason).to.equal('Unable to parse: Could not identify the URL.' +
         ' Please use the --url option.');
       expect(result.error).to.have.property('message', result.reason);
+      done();
+    });
+  });
+
+  it('convert request with explicit empty --url value', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request GET --url \'\''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.url).to.equal('');
+      expect(result.output[0].data.method).to.equal('GET');
+      done();
+    });
+  });
+
+  it('convert request with explicit empty --url and headers', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request GET --url \'\' --header \'Accept: application/json\''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.url).to.equal('');
+      expect(result.output[0].data.method).to.equal('GET');
+      expect(result.output[0].data.header).to.eql([{
+        key: 'Accept',
+        value: 'application/json'
+      }]);
+      done();
+    });
+  });
+
+  it('convert request with --url without value', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request GET --url'
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.url).to.equal('');
+      expect(result.output[0].data.method).to.equal('GET');
+      done();
+    });
+  });
+
+  it('convert request with --url followed by another option', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --url --request GET'
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.url).to.equal('');
+      expect(result.output[0].data.method).to.equal('GET');
+      done();
+    });
+  });
+
+  it('convert request with whitespace-only --url value', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl --request GET --url \'     \''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.url).to.equal('');
+      expect(result.output[0].data.method).to.equal('GET');
       done();
     });
   });


### PR DESCRIPTION
When a cURL command includes --url but the URL argument is missing, empty, whitespace-only, or immediately followed by another flag, we now import it as a Postman request with an empty URL instead of failing. Commands with no URL and no explicit --url still error as before.