### PR TITLE
Fixed issue where = char was not correctly escaped within urlencoded bodies.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -363,6 +363,10 @@ var program,
      * For --data-urlencode, each array entry is a single key=value pair.
      * Unlike --data/--data-raw where & separates multiple params within one value,
      * --data-urlencode treats & as a literal character in the value.
+     *
+     * @param {Array} dataArray - array of --data-urlencode argument values
+     * @param {Boolean} enableDecoding - whether to URI-decode keys and values
+     * @returns {Array} parsed key-value parameter objects
      */
     getDataForUrlEncodedParams: function(dataArray, enableDecoding) {
       var retVal = [],
@@ -393,6 +397,9 @@ var program,
     /**
      * For --data-urlencode entries, encode & within each entry so it
      * doesn't get confused with the separator between entries.
+     *
+     * @param {Array} arr - array of --data-urlencode argument values
+     * @returns {String} ampersand-joined string with values URL-encoded
      */
     convertUrlEncodeArrayToAmpersandString: function(arr) {
       return arr.map((entry) => {

--- a/src/lib.js
+++ b/src/lib.js
@@ -359,6 +359,22 @@ var program,
       return this.getDataForForm(dataArray, enableDecoding);
     },
 
+    /**
+     * For --data-urlencode, each array entry is a single key=value pair.
+     * Unlike --data/--data-raw where & separates multiple params within one value,
+     * --data-urlencode treats & as a literal character in the value.
+     */
+    getDataForUrlEncodedParams: function(dataArray, enableDecoding) {
+      var retVal = [],
+        trimmed;
+      for (let i = 0; i < dataArray.length; i++) {
+        trimmed = this.trimQuotesFromString(dataArray[i]);
+        if (trimmed === '') { continue; }
+        retVal = retVal.concat(this.getDataForForm([trimmed], enableDecoding));
+      }
+      return retVal;
+    },
+
     getLowerCaseHeader: function(hk, rHeaders) {
       for (var hKey in rHeaders) {
         if (rHeaders.hasOwnProperty(hKey)) {
@@ -372,6 +388,21 @@ var program,
 
     convertArrayToAmpersandString: function(arr) {
       return arr.join('&');
+    },
+
+    /**
+     * For --data-urlencode entries, encode & within each entry so it
+     * doesn't get confused with the separator between entries.
+     */
+    convertUrlEncodeArrayToAmpersandString: function(arr) {
+      return arr.map((entry) => {
+        var trimmed = this.trimQuotesFromString(entry),
+          eqIndex = trimmed.indexOf('=');
+        if (eqIndex === -1) {
+          return encodeURIComponent(trimmed);
+        }
+        return trimmed.substring(0, eqIndex) + '=' + encodeURIComponent(trimmed.substring(eqIndex + 1));
+      }).join('&');
     },
 
     sanitizeArgs: function(string) {
@@ -838,12 +869,12 @@ var program,
             request.body.mode = 'urlencoded';
             request.body.urlencoded = this.getDataForUrlEncoded(curlObj.data, true)
               .concat(this.getDataForUrlEncoded(curlObj.dataRaw, true))
-              .concat(this.getDataForUrlEncoded(curlObj.dataUrlencode, true))
+              .concat(this.getDataForUrlEncodedParams(curlObj.dataUrlencode, true))
               .concat(this.getDataForUrlEncoded(curlObj.dataAscii, false));
 
             bodyArr.push(this.convertArrayToAmpersandString(curlObj.data));
             bodyArr.push(this.convertArrayToAmpersandString(curlObj.dataRaw));
-            bodyArr.push(this.convertArrayToAmpersandString(curlObj.dataUrlencode));
+            bodyArr.push(this.convertUrlEncodeArrayToAmpersandString(curlObj.dataUrlencode));
             bodyArr.push(this.convertArrayToAmpersandString(curlObj.dataAscii));
             urlData = _.join(_.reject(bodyArr, (ele) => {
               return !ele;
@@ -852,7 +883,7 @@ var program,
           else {
             dataString = this.convertArrayToAmpersandString(curlObj.data);
             dataRawString = this.convertArrayToAmpersandString(curlObj.dataRaw);
-            dataUrlencode = this.convertArrayToAmpersandString(curlObj.dataUrlencode);
+            dataUrlencode = this.convertUrlEncodeArrayToAmpersandString(curlObj.dataUrlencode);
             dataAsciiString = this.convertArrayToAmpersandString(curlObj.dataAscii);
             bodyArr.push(this.trimQuotesFromString(dataString));
             bodyArr.push(this.trimQuotesFromString(dataRawString));

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -746,6 +746,32 @@ describe('Curl converter should', function() {
     done();
   });
 
+  it('should preserve & character in --data-urlencode values', function (done) {
+    var result = Converter.convertCurlToRequest('curl --location \'https://postman-echo.com/post\'' +
+    ' --header \'Content-Type: application/x-www-form-urlencoded\'' +
+    ' --data-urlencode \'client_id=test-agentic-external-uat\'' +
+    ' --data-urlencode \'grant_type=urn:ietf:params:oauth:grant-type:token-exchange\'' +
+    ' --data-urlencode \'client_secret=WUcjGDcl3RZ-T&gw9wlsA=1qCkilkRlR\'');
+    expect(result.body).to.have.property('mode', 'urlencoded');
+    expect(result.body.urlencoded.length).to.equal(3);
+    expect(result.body.urlencoded[0]).to.eql({
+      key: 'client_id',
+      value: 'test-agentic-external-uat',
+      type: 'text'
+    });
+    expect(result.body.urlencoded[1]).to.eql({
+      key: 'grant_type',
+      value: 'urn:ietf:params:oauth:grant-type:token-exchange',
+      type: 'text'
+    });
+    expect(result.body.urlencoded[2]).to.eql({
+      key: 'client_secret',
+      value: 'WUcjGDcl3RZ-T&gw9wlsA=1qCkilkRlR',
+      type: 'text'
+    });
+    done();
+  });
+
   it('[GitHub #8505] [GitHub #8953]: should correctly handle unicode characters present in data', function (done) {
     var result = Converter.convertCurlToRequest(`curl 'http://localhost:4000/graphql' \\
     --data-binary $'[{"operationName":"someMutation","variables":{"aRequiredVar":"foo\\x78bar\\u{1064A9}"},"query":` +

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -751,7 +751,7 @@ describe('Curl converter should', function() {
     ' --header \'Content-Type: application/x-www-form-urlencoded\'' +
     ' --data-urlencode \'client_id=test-agentic-external-uat\'' +
     ' --data-urlencode \'grant_type=urn:ietf:params:oauth:grant-type:token-exchange\'' +
-    ' --data-urlencode \'client_secret=WUcjGDcl3RZ-T&gw9wlsA=1qCkilkRlR\'');
+    ' --data-urlencode \'client_secret=HeLlO-T=1RlR\'');
     expect(result.body).to.have.property('mode', 'urlencoded');
     expect(result.body.urlencoded.length).to.equal(3);
     expect(result.body.urlencoded[0]).to.eql({
@@ -766,7 +766,7 @@ describe('Curl converter should', function() {
     });
     expect(result.body.urlencoded[2]).to.eql({
       key: 'client_secret',
-      value: 'WUcjGDcl3RZ-T&gw9wlsA=1qCkilkRlR',
+      value: 'HeLlO-T=1RlR',
       type: 'text'
     });
     done();


### PR DESCRIPTION
## Overview

The getDataForUrlEncoded function in src/lib.js joins all array entries with & then splits on &.

This is correct for --data and --data-raw where & separates multiple params within a single argument. But for --data-urlencode, each argument is a single key=value pair — the & in client_secret=HeLlO-T=1RlR is a literal character in the value, not a separator.

