### PR TITLE
Support the HTTP QUERY method in cURL import (CUE-6938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+-   Support importing cURL commands that use the HTTP QUERY method (RFC 9110-style safe, idempotent query method).
+
 ## [v1.8.5] - 2026-06-04
 
 ### Changed

--- a/src/lib.js
+++ b/src/lib.js
@@ -115,7 +115,7 @@ var program,
     validateCurlRequest: function(curlObj) {
     // must be a valid method
       var validMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'COPY', 'HEAD',
-          'OPTIONS', 'LINK', 'UNLINK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'],
+          'OPTIONS', 'LINK', 'UNLINK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND', 'QUERY'],
         singleWordXMethod,
         singleWordMethodPrefix = '-X',
         reqMethod = _.toUpper(curlObj.request);

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -237,6 +237,19 @@ describe('Curl converter should', function() {
     });
   });
 
+  it('parse a cURL command using the HTTP QUERY method', function (done) {
+    convert({
+      type: 'string',
+      data: 'curl \'http://localhost:3000/api/v1/my-api\' -X \'QUERY\'' +
+        ' -H \'accept: application/json\' --data-raw \'{}\''
+    }, function (err, result) {
+      expect(result.result).to.equal(true);
+      expect(result.output[0].data.method).to.equal('QUERY');
+      expect(result.output[0].data.url).to.equal('http://localhost:3000/api/v1/my-api');
+      done();
+    });
+  });
+
   it('throw an error for a cURL without URL defined correctly', function (done) {
     convert({
       type: 'string',


### PR DESCRIPTION
## Problem

Pasting a cURL command that uses the HTTP `QUERY` method fails to import with **"The method QUERY is not supported."** The same command with `-X POST` imports correctly.

Reported in [CUE-6938](https://postmanlabs.atlassian.net/browse/CUE-6938). Repro:

```
curl 'http://localhost:3000/api/v1/my-api' -X 'QUERY' -H 'accept: application/json' --data-raw '{}'
```

## Cause

`validateCurlRequest()` in `src/lib.js` checks the method against a hardcoded `validMethods` allowlist that did not include `QUERY`.

## Change

- Add `QUERY` to `validMethods`. QUERY is a standardized HTTP method (a safe, idempotent method that carries a request body — see [RFC 9110-style QUERY](https://datatracker.ietf.org/doc/rfc10008/)).
- Add a conversion test covering the reported repro.
- Changelog entry under `[Unreleased]`.

## Testing

```
npx mocha test/conversion.test.js
# 107 passing
```

Generated with [Claude Code](https://claude.com/claude-code)

[CUE-6938]: https://postmanlabs.atlassian.net/browse/CUE-6938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ