### PR TITLE
[SCA] Remediate vulnerable dependencies — SECINV-136

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+; Committed, token-free project .npmrc. Registry auth belongs in the user-level ~/.npmrc.
+; release-age gate — INERT until this repo moves to Node >= 20.17 AND npm >= 11.17.
+; Harmless on the current npm 10 toolchain; activates once the toolchain supports it.
+; Resolution-time only (dev/bots); npm ci never evaluates it.
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache",
       "dependencies": {
         "commander": "^2.20.3",
-        "lodash": "^4.17.21",
-        "shell-quote": "^1.8.2",
+        "lodash": "^4.18.1",
+        "shell-quote": "^1.9.0",
         "valid-url": "^1.0.9"
       },
       "devDependencies": {
@@ -1630,9 +1630,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -2520,9 +2521,10 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4449,9 +4451,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -5173,9 +5175,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "commander": "^2.20.3",
-    "lodash": "^4.17.21",
-    "shell-quote": "^1.8.2",
+    "lodash": "^4.18.1",
+    "shell-quote": "^1.9.0",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
> **SECINV-136 — patch/minor SCA hygiene mandate.** Automated dependency remediation scoped to
> patch/minor-fixable Critical/High findings (direct + transitive) from the `secinv-136_sca_scan`
> Wiz policy. Majors and no-fix findings are surfaced for human review, never auto-applied.
> Generated by `fix-sca-vulns`.

---

# SCA Remediation Report — curl-to-postman (secinv-136 mandate) — 2026-07-24

## Summary

All in-scope patch/minor Critical/High dependency findings driven to **0**. Both findings were
**direct** dependencies fixed by minor version bumps. No transitive stage or overrides were required.

- **Wiz verdict:** `WARN_BY_POLICY` (before) → **`PASSED_BY_POLICY`** (after) — 0 library findings remaining.
- **Distinct CVEs:** 3 before → **0** after — **net 3 resolved**.
- **Packages fixed:** 2 (both direct, minor bumps).
- **Overrides added:** 0.
- **New CVEs introduced:** 0.

## Results

| Metric | Before | After |
|--------|--------|-------|
| Distinct CVEs (Crit/High, in scope) | 3 | 0 |
| Critical | 1 | 0 |
| High | 2 | 0 |
| Wiz policy verdict | WARN_BY_POLICY | PASSED_BY_POLICY |

## Upgraded

| Package | From | To | Bump | Relationship | CVEs fixed |
|---------|------|----|----|--------------|------------|
| lodash | 4.17.21 | 4.18.1 | minor | direct | CVE-2026-4800 (High) |
| shell-quote | 1.8.3 | 1.9.0 | minor | direct | CVE-2026-9277 (Critical), CVE-2026-13311 (High) |

**Note on lodash target:** the scanner-suggested target `4.18.0` is a **deprecated bad release** whose
npm deprecation notice points back to `4.17.21` — which is still vulnerable to CVE-2026-4800. Advanced
to the next clean, non-deprecated release **`4.18.1`** (published 2026-04-01, signed by `jdalton`), which
clears the CVE. `shell-quote@1.9.0` (published 2026-06-25, signed by `ljharb`) clears both its CVEs. Both
targets verified via live `npm view` (integrity + maintainer + publish date); both are well older than the
7-day release-age floor.

## Tier commits

1. `chore(security): set up install guardrails (release-age gate)` — adds a committed, token-free `.npmrc`
   with an inert `min-release-age=7` gate.
2. `[SCA] direct minor upgrades — 2026-07-24` — lodash + shell-quote minor bumps.

## Baseline & validation

- **Test baseline:** `npm test` (eslint + mocha) — **122 passing**, 0 failing (clean).
- **Post-fix tests:** `npm test` — **122 passing**, 0 failing — no regressions.
- **Frozen-install integrity gate:** `npm ci` exits **0** on the final committed tree (npm 10 / Node 18).
- **Deprecation gate:** no version this run introduced is deprecated.
- **Final Wiz re-scan:** `PASSED_BY_POLICY`, 0 library findings.

## No fix / major (out of scope)

None. There were no major-only, no-fix, or `@postman/*`-pinned findings.

## Install guardrails

- **Frozen installs (Guardrail 1):** already satisfied — CI installs via `npm ci`; no Dockerfiles / bare
  installs present.
- **Release-age gate (Guardrail 2):** a committed, token-free `.npmrc` with `min-release-age=7` was added.
  It is **inert on the repo's current npm 10 toolchain** and activates once the repo moves to Node ≥ 20.17
  + npm ≥ 11.17. No `@postman/*` deps present, so no carve-out is needed.
- **Toolchain pin (Guardrail 3):** Bucket B — the repo targets Node 18 (`.nvmrc` 18.13.0, `engines.node
  >=12`, CI matrix 12/16/18), which cannot run npm 11. `engines.npm` / `engine-strict` were intentionally
  **not** set (they would hard-fail every install on npm 10). Standardized PM major = **npm 10**.

## Needs human

- **Node-major bump (guardrail enabler):** to make the release-age gate + first-party carve-out **live**,
  the repo needs Node ≥ 20.17 + npm ≥ 11.17. This is a platform decision for the repo owner; not made here.

## Wiz report

- Pre-fix scan event and post-fix scan event captured in the run (verdict WARN → PASSED).
